### PR TITLE
Add missing export macro to scheme.h

### DIFF
--- a/include/saucer/scheme.h
+++ b/include/saucer/scheme.h
@@ -30,7 +30,7 @@ extern "C"
 
     struct saucer_scheme_request;
 
-    void saucer_scheme_request_free(saucer_scheme_request *);
+    SAUCER_EXPORT void saucer_scheme_request_free(saucer_scheme_request *);
 
     /*[[sc::requires_free]]*/ SAUCER_EXPORT char *saucer_scheme_request_url(saucer_scheme_request *);
     /*[[sc::requires_free]]*/ SAUCER_EXPORT char *saucer_scheme_request_method(saucer_scheme_request *);


### PR DESCRIPTION
The `saucer_scheme_request_free` function just delete the object and has no particular meaning other than portability in future versions. 

However, it seems worth adding (macro was lost).